### PR TITLE
fix: 修复语音连接完成后，马上说话会输出少内容的问题

### DIFF
--- a/asr/app/speechrecognizer.js
+++ b/asr/app/speechrecognizer.js
@@ -190,6 +190,7 @@ export class SpeechRecognizer {
                         } else  if (response.result.slice_type === 2) {
                             if (!this.isSentenceBegin) {
                                 this.OnSentenceBegin(response);
+                                this.OnRecognitionResultChange(response);
                             }
                             this.OnSentenceEnd(response);
                         } else {


### PR DESCRIPTION
连接完成后，马上说话，你一次返回的结果会是下面这样的，会 slice_type === 2，但是有内容，但是 change回调没有触发

emotion_type: null
end_time: 2040
index: 0
slice_type: 2
start_time: 480
voice_text_str: "你好"